### PR TITLE
Major refactoring of Agent class family.

### DIFF
--- a/Game Off 2024 Agency/Assets/Scriptable Objects/AgentStatTemplateSO.asset
+++ b/Game Off 2024 Agency/Assets/Scriptable Objects/AgentStatTemplateSO.asset
@@ -1,0 +1,31 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a31e0f7ceb6a3746a5172fc8c3f5290, type: 3}
+  m_Name: AgentStatTemplateSO
+  m_EditorClassIdentifier: 
+  stats:
+  - name: HP
+    description: Hit Points
+    defaultValue: 100
+    icon: {fileID: 0}
+  - name: MP
+    description: Mana Points
+    defaultValue: 50
+    icon: {fileID: 0}
+  - name: San
+    description: Sanity
+    defaultValue: 100
+    icon: {fileID: 0}
+  - name: Luck
+    description: Luck
+    defaultValue: 10
+    icon: {fileID: 0}

--- a/Game Off 2024 Agency/Assets/Scriptable Objects/AgentStatTemplateSO.asset.meta
+++ b/Game Off 2024 Agency/Assets/Scriptable Objects/AgentStatTemplateSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 38a7f90e9265fd844a232724905883d6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Game Off 2024 Agency/Assets/Scriptable Objects/JamesBondSO.asset
+++ b/Game Off 2024 Agency/Assets/Scriptable Objects/JamesBondSO.asset
@@ -16,5 +16,96 @@ MonoBehaviour:
   description: Legendary Agent
   profilePhoto: {fileID: 7114782437234694498, guid: 1ef0225bbbc52fc4796d000b9196f69a, type: 3}
   strength: 10
-  speed: 10
+  constitution: 0
+  size: 0
+  dexterity: 0
+  appearance: 0
+  education: 0
   intelligence: 10
+  power: 0
+  accounting: 0
+  anthropology: 0
+  appraise: 0
+  archaeology: 0
+  artCraft1: 0
+  artCraft2: 0
+  artCraft3: 0
+  charm: 0
+  climb: 0
+  computerUse: 0
+  creditRating: 0
+  cthulhuMythos: 0
+  disguise: 0
+  dodge: 0
+  driveAuto: 0
+  elecRepair: 0
+  electronics: 0
+  fastTalk: 0
+  fightingBrawl: 0
+  fighting2: 0
+  fighting3: 0
+  firearmsAiming: 0
+  firearmsHipshot: 0
+  firearms3: 0
+  firstAid: 0
+  history: 0
+  intimidate: 0
+  jump: 0
+  languageOther1: 0
+  languageOther2: 0
+  languageOwn: 0
+  law: 0
+  libraryUse: 0
+  listen: 0
+  locksmith: 0
+  mechRepair: 0
+  medicine: 0
+  naturalWorld: 0
+  navigate: 0
+  occult: 0
+  opHvMachine: 0
+  persuade: 0
+  pilot: 0
+  psychology: 0
+  psychanalysis: 0
+  science1: 0
+  science2: 0
+  science3: 0
+  sleightOfHand: 0
+  spotHidden: 0
+  stealth: 0
+  survival1: 0
+  swim: 0
+  throw1: 0
+  track: 0
+  other1: 0
+  other2: 0
+  other3: 0
+  other4: 0
+  other5: 0
+  statTemplate: {fileID: 11400000, guid: 38a7f90e9265fd844a232724905883d6, type: 2}
+  stats:
+  - template:
+      name: 
+      description: 
+      defaultValue: 0
+      icon: {fileID: 0}
+    currentValue: 0
+  - template:
+      name: 
+      description: 
+      defaultValue: 0
+      icon: {fileID: 0}
+    currentValue: 0
+  - template:
+      name: 
+      description: 
+      defaultValue: 0
+      icon: {fileID: 0}
+    currentValue: 0
+  - template:
+      name: 
+      description: 
+      defaultValue: 0
+      icon: {fileID: 0}
+    currentValue: 0

--- a/Game Off 2024 Agency/Assets/Scriptable Objects/KimPossibleSO.asset
+++ b/Game Off 2024 Agency/Assets/Scriptable Objects/KimPossibleSO.asset
@@ -16,5 +16,96 @@ MonoBehaviour:
   description: Call me Beep me
   profilePhoto: {fileID: 3800605366432236211, guid: 89ff22d79f0fea949be5506a5a7fb309, type: 3}
   strength: 5
-  speed: 5
+  constitution: 0
+  size: 0
+  dexterity: 0
+  appearance: 0
+  education: 0
   intelligence: 5
+  power: 0
+  accounting: 0
+  anthropology: 0
+  appraise: 0
+  archaeology: 0
+  artCraft1: 0
+  artCraft2: 0
+  artCraft3: 0
+  charm: 0
+  climb: 0
+  computerUse: 0
+  creditRating: 0
+  cthulhuMythos: 0
+  disguise: 0
+  dodge: 0
+  driveAuto: 0
+  elecRepair: 0
+  electronics: 0
+  fastTalk: 0
+  fightingBrawl: 0
+  fighting2: 0
+  fighting3: 0
+  firearmsAiming: 0
+  firearmsHipshot: 0
+  firearms3: 0
+  firstAid: 0
+  history: 0
+  intimidate: 0
+  jump: 0
+  languageOther1: 0
+  languageOther2: 0
+  languageOwn: 0
+  law: 0
+  libraryUse: 0
+  listen: 0
+  locksmith: 0
+  mechRepair: 0
+  medicine: 0
+  naturalWorld: 0
+  navigate: 0
+  occult: 0
+  opHvMachine: 0
+  persuade: 0
+  pilot: 0
+  psychology: 0
+  psychanalysis: 0
+  science1: 0
+  science2: 0
+  science3: 0
+  sleightOfHand: 0
+  spotHidden: 0
+  stealth: 0
+  survival1: 0
+  swim: 0
+  throw1: 0
+  track: 0
+  other1: 0
+  other2: 0
+  other3: 0
+  other4: 0
+  other5: 0
+  statTemplate: {fileID: 11400000, guid: 38a7f90e9265fd844a232724905883d6, type: 2}
+  stats:
+  - template:
+      name: HP
+      description: Hit Points
+      defaultValue: 100
+      icon: {fileID: 0}
+    currentValue: 100
+  - template:
+      name: MP
+      description: Mana Points
+      defaultValue: 50
+      icon: {fileID: 0}
+    currentValue: 50
+  - template:
+      name: San
+      description: Sanity
+      defaultValue: 100
+      icon: {fileID: 0}
+    currentValue: 100
+  - template:
+      name: Luck
+      description: Luck
+      defaultValue: 10
+      icon: {fileID: 0}
+    currentValue: 10

--- a/Game Off 2024 Agency/Assets/Scriptable Objects/WillSmithSO.asset
+++ b/Game Off 2024 Agency/Assets/Scriptable Objects/WillSmithSO.asset
@@ -16,5 +16,96 @@ MonoBehaviour:
   description: Really Experienced Guy
   profilePhoto: {fileID: -3225110325270304424, guid: 46c705e684dd5de409200eb307f0c993, type: 3}
   strength: 4
-  speed: 3
+  constitution: 0
+  size: 0
+  dexterity: 0
+  appearance: 0
+  education: 0
   intelligence: 1
+  power: 0
+  accounting: 0
+  anthropology: 0
+  appraise: 0
+  archaeology: 0
+  artCraft1: 0
+  artCraft2: 0
+  artCraft3: 0
+  charm: 0
+  climb: 0
+  computerUse: 0
+  creditRating: 0
+  cthulhuMythos: 0
+  disguise: 0
+  dodge: 0
+  driveAuto: 0
+  elecRepair: 0
+  electronics: 0
+  fastTalk: 0
+  fightingBrawl: 0
+  fighting2: 0
+  fighting3: 0
+  firearmsAiming: 0
+  firearmsHipshot: 0
+  firearms3: 0
+  firstAid: 0
+  history: 0
+  intimidate: 0
+  jump: 0
+  languageOther1: 0
+  languageOther2: 0
+  languageOwn: 0
+  law: 0
+  libraryUse: 0
+  listen: 0
+  locksmith: 0
+  mechRepair: 0
+  medicine: 0
+  naturalWorld: 0
+  navigate: 0
+  occult: 0
+  opHvMachine: 0
+  persuade: 0
+  pilot: 0
+  psychology: 0
+  psychanalysis: 0
+  science1: 0
+  science2: 0
+  science3: 0
+  sleightOfHand: 0
+  spotHidden: 0
+  stealth: 0
+  survival1: 0
+  swim: 0
+  throw1: 0
+  track: 0
+  other1: 0
+  other2: 0
+  other3: 0
+  other4: 0
+  other5: 0
+  statTemplate: {fileID: 11400000, guid: 38a7f90e9265fd844a232724905883d6, type: 2}
+  stats:
+  - template:
+      name: HP
+      description: Hit Points
+      defaultValue: 100
+      icon: {fileID: 0}
+    currentValue: 100
+  - template:
+      name: MP
+      description: Mana Points
+      defaultValue: 50
+      icon: {fileID: 0}
+    currentValue: 50
+  - template:
+      name: San
+      description: Sanity
+      defaultValue: 100
+      icon: {fileID: 0}
+    currentValue: 100
+  - template:
+      name: Luck
+      description: Luck
+      defaultValue: 10
+      icon: {fileID: 0}
+    currentValue: 10

--- a/Game Off 2024 Agency/Assets/Scripts/Behaviors/Agent.cs
+++ b/Game Off 2024 Agency/Assets/Scripts/Behaviors/Agent.cs
@@ -85,6 +85,8 @@ public class Agent : MonoBehaviour
     public bool IsPoisoned => activeEffects.Any(effect => effect.effectSO is EffectSO_Poisoned);
     public bool IsInsane => activeEffects.Any(effect => effect.effectSO is EffectSO_Insane);
 
+    // Corris: List of current stats (standard)
+    public List<AgentStat> currentStats = new List<AgentStat>();
 
     // List of active effects
     private List<Effect> activeEffects = new List<Effect>();
@@ -165,6 +167,9 @@ public class Agent : MonoBehaviour
         other4 = agentSO.other4;
         other5 = agentSO.other5;
 
+        // Initializing standard (Corris) AgentStats
+        InitializeAgentStats();
+
         if (UnityEngine.SceneManagement.SceneManager.GetActiveScene().name == "CorrisScene-Sandbox")
         {
             // (Corris) TEST: Apply some effects to the agent
@@ -184,7 +189,45 @@ public class Agent : MonoBehaviour
         // Corris: Call when needed (not sure do we have turn based system or real time)
         // UpdateEffects();
     }
+    
+    public void InitializeAgentStats()
+    {
+        if (agentSO == null)
+        {
+            Debug.LogError("AgentSO is not assigned!");
+            return;
+        }
+        if (agentSO.statTemplate == null)
+        {
+            Debug.LogError("StatTemplate is not assigned!");
+            return;
+        }
 
+        // Копируем шаблон и создаём текущие значения
+        currentStats = agentSO.statTemplate.stats
+            .Select(template => new AgentStat(template))
+            .ToList();
+    }
+
+    public void SetStatValue(string name, float newValue)
+    {
+        var stat = currentStats.FirstOrDefault(s => s.template.name == name);
+        if (stat != null)
+        {
+          //  stat.currentValue = Mathf.Clamp(stat.currentValue + delta, 0, stat.template.defaultValue);
+            stat.currentValue = newValue;
+        }
+    }
+
+    public float GetStatValue(string name)
+    {
+        var stat = currentStats.FirstOrDefault(s => s.template.name == name);
+        if (stat != null)
+        {
+            return stat.currentValue;
+        }
+        return 0;
+    }
 
     public bool ApplyEffect(Effect effect)
     {
@@ -219,7 +262,7 @@ public class Agent : MonoBehaviour
 
     public void TakeDamage(float damage)
     {
-        // наносим урон агенту
+        // hitting agent
         Debug.Log($"Agent: {name} takes {damage} damage");
 
     }

--- a/Game Off 2024 Agency/Assets/Scripts/Behaviors/AgentStat.cs
+++ b/Game Off 2024 Agency/Assets/Scripts/Behaviors/AgentStat.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+[System.Serializable]
+public class AgentStat
+{
+    public AgentStatTemplate template; // Ссылка на шаблон
+    public float currentValue;         // Текущее значение
+
+    public AgentStat(AgentStatTemplate template)
+    {
+        this.template = template;
+        this.currentValue = template.defaultValue;
+    }
+}

--- a/Game Off 2024 Agency/Assets/Scripts/Behaviors/AgentStat.cs.meta
+++ b/Game Off 2024 Agency/Assets/Scripts/Behaviors/AgentStat.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 75ab418785ff63748b0cf335c665f5dd

--- a/Game Off 2024 Agency/Assets/Scripts/Behaviors/AgentStatTemplate.cs
+++ b/Game Off 2024 Agency/Assets/Scripts/Behaviors/AgentStatTemplate.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+
+// This class is a template for the AgentStat class.
+[System.Serializable]
+public class AgentStatTemplate
+{
+    public string name;
+    public string description;
+    public float defaultValue;
+    public Sprite icon;
+}

--- a/Game Off 2024 Agency/Assets/Scripts/Behaviors/AgentStatTemplate.cs.meta
+++ b/Game Off 2024 Agency/Assets/Scripts/Behaviors/AgentStatTemplate.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7fc476b00b8e2674cbf00542393a59e6

--- a/Game Off 2024 Agency/Assets/Scripts/Scriptable Objects Templates/AgentSO.cs
+++ b/Game Off 2024 Agency/Assets/Scripts/Scriptable Objects Templates/AgentSO.cs
@@ -1,4 +1,10 @@
+using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
+#if UNITY_EDITOR   // to react on change in Unity Editor - AgentStarTemplateSO field of AgentSO
+using UnityEditor;
+#endif
+
 
 [CreateAssetMenu(fileName = "AgentSO", menuName = "Scriptable Objects/AgentSO")]
 public class AgentSO : ScriptableObject
@@ -76,5 +82,90 @@ public class AgentSO : ScriptableObject
     public int other3;
     public int other4;
     public int other5;
+
+    // (Corris:) 
+    [Header("Stats")]
+    public AgentStatTemplateSO statTemplate; // Link to shadblon with list of Stat parameters
+    // All stats - edit in Unity Editor
+    public List<AgentStat> stats = new();
+
+    // 'Constructor' to add default properties to list
+    private void OnEnable()
+    {
+#if UNITY_EDITOR
+        if (statTemplate == null) // if template didn't set - try to find it in Unity
+        {
+            FindStatTemplate("AgentStatTemplateSO");
+        }
+#endif
+        if (statTemplate != null)
+            SyncStatsWithTemplate();
+    }
+
+    // Update stats list if template was changed (need this as reaction to Template changed in Unity Editor
+    private void OnValidate()
+    {
+        if (statTemplate != null)
+        {
+            SyncStatsWithTemplate();
+        }
+    }
+
+
+    private void SyncStatsWithTemplate()
+    {
+        // if list is empty, add all stats from template
+        if (stats.Count == 0)
+        {
+            InitializeStats();
+            return;
+        }
+
+        // check if all stats from template are in list
+        foreach (var templateStat in statTemplate.stats)
+        {
+            if (!stats.Any(s => s.template == templateStat))
+            {
+                stats.Add(new AgentStat(templateStat)); // add new stat
+            }
+        }
+
+        // remove stats that are not in template  (maybe they from old ersion of template)
+        stats.RemoveAll(s => !statTemplate.stats.Contains(s.template));
+    }
+
+    private void InitializeStats()
+    {
+        stats = statTemplate.stats
+            .Select(template => new AgentStat(template))
+            .ToList();
+    }
+
+#if UNITY_EDITOR
+    private void FindStatTemplate(string _AgentStatTemplateName)
+    {
+        // Looking for existing in Unity Editor  template AgentStatTemplateSO
+      //  string[] guids = AssetDatabase.FindAssets("t:AgentStatTemplateSO");
+        string[] guids = AssetDatabase.FindAssets("t:"+ _AgentStatTemplateName);
+        if (guids.Length > 0)
+        {
+            string path = AssetDatabase.GUIDToAssetPath(guids[0]);
+            statTemplate = AssetDatabase.LoadAssetAtPath<AgentStatTemplateSO>(path);
+        }
+        else
+        {
+       /*     // If not found - creating new one
+            statTemplate = ScriptableObject.CreateInstance<AgentStatTemplateSO>();
+            string assetPath = "Assets/AgentStatTemplateSO.asset";
+            AssetDatabase.CreateAsset(statTemplate, assetPath);
+            AssetDatabase.SaveAssets();
+            Debug.Log("Created new AgentStatTemplateSO at " + assetPath);   
+       */
+        }
+
+        EditorUtility.SetDirty(this); // Mark object as dirty to save changes
+    }
+#endif
+
 
 }

--- a/Game Off 2024 Agency/Assets/Scripts/Scriptable Objects Templates/AgentStatTemplateSO.cs
+++ b/Game Off 2024 Agency/Assets/Scripts/Scriptable Objects Templates/AgentStatTemplateSO.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+[CreateAssetMenu(fileName = "AgentStatTemplateSO", menuName = "Scriptable Objects/AgentStatTemplateSO")]
+public class AgentStatTemplateSO : ScriptableObject
+{
+    public List<AgentStatTemplate> stats = new List<AgentStatTemplate>();
+
+    private void OnEnable()
+    {
+        // Добавляем параметры, если их нет
+        if (stats.Count == 0)
+        {
+            stats.Add(new AgentStatTemplate { name = "HP", description = "Hit Points", defaultValue = 100 });
+            stats.Add(new AgentStatTemplate { name = "MP", description = "Mana Points", defaultValue = 50 });
+            stats.Add(new AgentStatTemplate { name = "San", description = "Sanity", defaultValue = 100 });
+            stats.Add(new AgentStatTemplate { name = "Luck", description = "Luck", defaultValue = 10 });
+        }
+    }
+}

--- a/Game Off 2024 Agency/Assets/Scripts/Scriptable Objects Templates/AgentStatTemplateSO.cs.meta
+++ b/Game Off 2024 Agency/Assets/Scripts/Scriptable Objects Templates/AgentStatTemplateSO.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7a31e0f7ceb6a3746a5172fc8c3f5290

--- a/Game Off 2024 Agency/Assets/Scripts/Systems/ArtifactManager.cs
+++ b/Game Off 2024 Agency/Assets/Scripts/Systems/ArtifactManager.cs
@@ -86,7 +86,7 @@ public class ArtifactManager : MonoBehaviour
         // Instantiate a new artifact using the artifactPrefab as a child of the ArtifactManager.
         Artifact newArtifact = Instantiate(artifactPrefab, this.transform);
 
-        // Initialize the new artifact with the template's data.
+        // InitializeAgentStats the new artifact with the template's data.
         newArtifact.InitializeFromTemplate(template);
 
         // Add the new artifact to the agencyArtifactCatalog.


### PR DESCRIPTION
I was about to add some stats @Mystic4LLight UTC +7  asked for, but the way Stas present in Agent class was not flexible enough. So I did it another way.

Now we have
AgentStatTemplateSO - where we can add any Stat as you see on second screenshot. AgentStatTemplate - list of fields for a single stat (Name, Description, Image, Value ... etc.) AgentStat - hold single changeable Value (+ link to template with Name, Description...) AgentSO - now have List of AgentStat and statTemplate Agent - now hold list of Current Stats  (different values for different agents)

So, not we can operate on any Stat same way.
No need to have lot of different variables.
It can be changed via Editor in AgentStatTemplateSO.

All old code should continue to work, because I didn't touch old stats. But to manipulate them (affect Strength by the Artifact for example) - they have to be changed to New version of Stat. Well, it should be easy.

To get stat value - call  Agent.GetStatValue( nameStat ) To set value  - call Agent.SetStatValue( nameStat, valueStat )